### PR TITLE
Update event details to JPrime 2025

### DIFF
--- a/src/main/jasper/badge.jrxml
+++ b/src/main/jasper/badge.jrxml
@@ -13,7 +13,7 @@
 		<defaultValueExpression><![CDATA["Lunch day 1"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="event" class="java.lang.String">
-		<defaultValueExpression><![CDATA["JPrime 2023"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["JPrime 2025"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="qr" class="java.lang.String">
 		<defaultValueExpression><![CDATA["{\"event\": \"" + $P{event} + "\", \"name\": \"" + $P{name} + "\", \"company\": \"" + $P{company} + "\", \"email\": \"" + $P{email} + "\", \"type\" : \"" + $P{type} + "\"}"]]></defaultValueExpression>

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 org.bgjug.jprime.registration.url.list=https://jprime.io,http://localhost:8080
-org.bgjug.jprime.registration.year=2024
-org.bgjug.jprime.registration.first.day=2024-05-28
-org.bgjug.jprime.registration.second.day=2024-05-29
+org.bgjug.jprime.registration.year=2025
+org.bgjug.jprime.registration.first.day=2025-05-14
+org.bgjug.jprime.registration.second.day=2025-05-15
 smallrye.config.locations=.


### PR DESCRIPTION
Updated event parameters and configuration to reflect the 2025 schedule, including new default values in badge templates and revised event dates in the configuration file. These changes prepare the system for the upcoming event year.